### PR TITLE
Fix strides property

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ function ndarrayLike( v ) {
 		typeof v === 'object' &&
 		typeof v.data === 'object' &&
 		typeof v.shape === 'object' &&
-		typeof v.strides === 'object' &&
+		typeof v.stride === 'object' &&
 		typeof v.offset === 'number' &&
 		typeof v.dtype === 'string' &&
 		typeof v.length === 'number';

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,7 @@ function ndarrayLike( v ) {
 		typeof v.shape === 'object' &&
 		typeof v.stride === 'object' &&
 		typeof v.offset === 'number' &&
-		typeof v.dtype === 'string' &&
-		typeof v.length === 'number';
+		typeof v.dtype === 'string';
 } // end FUNCTION ndarrayLike()
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,7 @@ function create() {
 	var ndarray = {};
 	ndarray.data = [1,2,3,4];
 	ndarray.shape = [2,2];
-	ndarray.strides = [2,1];
+	ndarray.stride = [2,1];
 	ndarray.offset = 0;
 	ndarray.dtype = 'generic';
 	ndarray.length = 4;


### PR DESCRIPTION
Right now `ndarray` instances are not ndarray-like.
Is that because of `strides` property?